### PR TITLE
[7.2.1] Enforce and await cleanup in `StarlarkBaseExternalContext` (#22814)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -71,6 +71,7 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
         timeoutScaling,
         processWrapper,
         starlarkSemantics,
+        ModuleExtensionEvaluationProgress.moduleExtensionEvaluationContextString(extensionId),
         remoteExecutor,
         /* allowWatchingPathsOutsideWorkspace= */ false);
     this.extensionId = extensionId;
@@ -83,8 +84,10 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
   }
 
   @Override
-  protected String getIdentifyingStringForLogging() {
-    return ModuleExtensionEvaluationProgress.moduleExtensionEvaluationContextString(extensionId);
+  protected boolean shouldDeleteWorkingDirectoryOnClose(boolean successful) {
+    // The contents of the working directory are purely ephemeral, only the repos instantiated by
+    // the extension are considered its results.
+    return true;
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -43,10 +43,12 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -114,7 +116,8 @@ public class HttpDownloaderTest {
               });
 
       Path resultingFile =
-          downloadManager.download(
+          download(
+              downloadManager,
               Collections.singletonList(
                   new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
               Collections.emptyMap(),
@@ -180,7 +183,8 @@ public class HttpDownloaderTest {
       urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile =
-          downloadManager.download(
+          download(
+              downloadManager,
               urls,
               Collections.emptyMap(),
               Collections.emptyMap(),
@@ -248,7 +252,8 @@ public class HttpDownloaderTest {
       urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile =
-          downloadManager.download(
+          download(
+              downloadManager,
               urls,
               Collections.emptyMap(),
               Collections.emptyMap(),
@@ -318,7 +323,8 @@ public class HttpDownloaderTest {
 
       Path outputFile = fs.getPath(workingDir.newFile().getAbsolutePath());
       try {
-        downloadManager.download(
+        download(
+            downloadManager,
             urls,
             Collections.emptyMap(),
             Collections.emptyMap(),
@@ -657,7 +663,8 @@ public class HttpDownloaderTest {
     assertThrows(
         ContentLengthMismatchException.class,
         () ->
-            downloadManager.download(
+            download(
+                downloadManager,
                 ImmutableList.of(new URL("http://localhost")),
                 Collections.emptyMap(),
                 ImmutableMap.of(),
@@ -697,7 +704,8 @@ public class HttpDownloaderTest {
         .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
 
     Path result =
-        downloadManager.download(
+        download(
+            downloadManager,
             ImmutableList.of(new URL("http://localhost")),
             ImmutableMap.of(),
             ImmutableMap.of(),
@@ -742,7 +750,8 @@ public class HttpDownloaderTest {
         .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
 
     Path result =
-        downloadManager.download(
+        download(
+            downloadManager,
             ImmutableList.of(new URL("http://localhost")),
             ImmutableMap.of(),
             ImmutableMap.of(),
@@ -757,5 +766,36 @@ public class HttpDownloaderTest {
     assertThat(times.get()).isEqualTo(4);
     String content = new String(result.getInputStream().readAllBytes(), UTF_8);
     assertThat(content).isEqualTo("content");
+  }
+
+  public Path download(
+      DownloadManager downloadManager,
+      List<URL> originalUrls,
+      Map<String, List<String>> headers,
+      Map<URI, Map<String, List<String>>> authHeaders,
+      Optional<Checksum> checksum,
+      String canonicalId,
+      Optional<String> type,
+      Path output,
+      ExtendedEventHandler eventHandler,
+      Map<String, String> clientEnv,
+      String context)
+      throws IOException, InterruptedException {
+    try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
+      Future<Path> future =
+          downloadManager.startDownload(
+              executorService,
+              originalUrls,
+              headers,
+              authHeaders,
+              checksum,
+              canonicalId,
+              type,
+              output,
+              eventHandler,
+              clientEnv,
+              context);
+      return downloadManager.finalizeDownload(future);
+    }
   }
 }

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -1030,6 +1030,39 @@ class BazelModuleTest(test_base.TestBase):
         'rule //:foo @other_module//:bar @@canonical_name//:baz', stderr
     )
 
+  def testPendingDownloadDetected(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'ext = use_extension("extensions.bzl", "ext")',
+            'use_repo(ext, "ext")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile(
+        'extensions.bzl',
+        [
+            'repo_rule = repository_rule(lambda _: None)',
+            'def ext_impl(module_ctx):',
+            '  repo_rule(name = "ext")',
+            (
+                '  module_ctx.download(url = "https://bcr.bazel.build", output'
+                ' = "download", block = False)'
+            ),
+            'ext = module_extension(implementation = ext_impl)',
+        ],
+    )
+    exit_code, _, stderr = self.RunBazel(
+        ['build', '--nobuild', '@ext//:all'],
+        allow_failure=True,
+    )
+    self.AssertExitCode(exit_code, 48, stderr)
+    self.assertIn(
+        'ERROR: Pending asynchronous work after module extension ext in'
+        ' @@//:extensions.bzl finished execution',
+        stderr,
+    )
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/test/shell/bazel/jdeps_test.sh
+++ b/src/test/shell/bazel/jdeps_test.sh
@@ -72,7 +72,8 @@ function test_jdeps() {
   # src/test/shell/bazel/jdeps_class_denylist.txt.
   find . -type f -iname \*class | \
     grep -vFf "$denylist" | \
-    xargs -s 262144 ../jdk/reduced/bin/jdeps --list-reduced-deps --ignore-missing-deps | \
+    sort -r | \
+    xargs -s 400000 ../jdk/reduced/bin/jdeps --list-reduced-deps --ignore-missing-deps | \
     grep -v "unnamed module" > ../jdeps \
     || fail "Failed to run jdeps on non denylisted class files."
   cd ..


### PR DESCRIPTION
`StarlarkBaseExternalContext` now implements `AutoCloseable` and, in `close()`:
1. Cancels all pending async tasks.
2. Awaits their termination.
3. Cleans up the working directory (always for module extensions, on failure for repo rules).
4. Fails if there were pending async tasks in an otherwise successful evaluation.

Previously, module extensions didn't do any of those. Repo rules did 1 and 4 and sometimes 3, but not in all cases.

This change required replacing the fixed-size thread pool in `DownloadManager` with virtual threads, thereby resolving a TODO about not using a fixed-size thread pool for the `GrpcRemoteDownloader`.

Work towards #22680
Work towards #22748

Closes #22772

PiperOrigin-RevId: 644669599
Change-Id: Ib71e5bf346830b92277ac2bd473e11c834cb2624

Closes #22775